### PR TITLE
Implement SIBC (Leontovich boundary condition) for good conductors 

### DIFF
--- a/.github/workflows/badge.yml
+++ b/.github/workflows/badge.yml
@@ -1,0 +1,29 @@
+name: Lines of code
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  run_tests:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Make the default shell a login shell, so that conda is initialised properly
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: Make Code Badge
+      uses: shadowmoose/GHA-LoC-Badge@1.0.0
+      id: badge
+      with:
+        debug: true
+        directory: ./wakis/
+        badge: ./docs/img/badge.svg
+        patterns: '*.js'  # Patterns in the format of a '.gitignore' file, separated by pipes.
+        ignore: 'node_modules'

--- a/tests/test_007_mpi_lossy_cavity.py
+++ b/tests/test_007_mpi_lossy_cavity.py
@@ -92,7 +92,7 @@ class TestMPILossyCavity:
                 'ymin': -0.25999999046325684, 'ymax': 0.25999999046325684,
                 'zmin': -0.25, 'zmax': 0.550000011920929,
                 'stl_solids': {'cavity': 'tests/stl/007_vacuum_cavity.stl', 'shell': 'tests/stl/007_lossymetal_shell.stl'},
-                'stl_materials': {'cavity': 'vacuum', 'shell': [30, 1.0, 30]},
+                'stl_materials': {'cavity': [1.0, 1.0], 'shell': [30, 1.0, 30]},
                 'gridInitializationTime': 0}
 
     solverLogs = {'use_gpu': False, 'use_mpi': False, 'background': 'pec',
@@ -202,7 +202,7 @@ class TestMPILossyCavity:
             for n in tqdm(range(Nt)):
 
                 beam.update(solver, n*solver.dt)
-                solver.mpi_one_step()
+                solver.one_step()
 
             Ez = solver.mpi_gather('Ez', x=int(Nx/2), y=int(Ny/2))
             if solver.rank == 0:

--- a/tests/test_007_mpi_lossy_cavity.py
+++ b/tests/test_007_mpi_lossy_cavity.py
@@ -257,7 +257,9 @@ class TestMPILossyCavity:
         global solver
         filename = 'mpi_test_state.h5'
         solver.save_state(filename)
-        solver.comm.Barrier()  # Ensure all processes reach this point
+
+        if use_mpi:
+            solver.comm.Barrier()  # Ensure all processes reach this point
         assert os.path.exists(filename), "MPI savestate file not created"
 
     def test_mpi_load_state(self):
@@ -267,7 +269,8 @@ class TestMPILossyCavity:
 
         # Test MPI loadstate
         filename = 'mpi_test_state.h5'
-        solver.comm.Barrier()  # Ensure all processes reach this point
+        if use_mpi:
+            solver.comm.Barrier()  # Ensure all processes reach this point
         assert os.path.exists(filename), "MPI loadstate file not found"
         solver.load_state(filename)
 

--- a/tests/test_007_mpi_lossy_cavity.py
+++ b/tests/test_007_mpi_lossy_cavity.py
@@ -252,6 +252,30 @@ class TestMPILossyCavity:
                 xscale='linear', yscale='linear',
                 off_screen=True, title=self.img_folder+'Ez1d', n=3000)
 
+    def test_mpi_save_state(self):
+        # Test MPI savestate
+        global solver
+        filename = 'mpi_test_state.h5'
+        solver.save_state(filename)
+        solver.comm.Barrier()  # Ensure all processes reach this point
+        assert os.path.exists(filename), "MPI savestate file not created"
+
+    def test_mpi_load_state(self):
+        global solver
+        E_slice = solver.E[int(solver.Nx/2), int(solver.Ny/2), :, 'z'].copy()  # Save current field slice
+        solver.reset_fields()  # Reset fields to zero
+
+        # Test MPI loadstate
+        filename = 'mpi_test_state.h5'
+        solver.comm.Barrier()  # Ensure all processes reach this point
+        assert os.path.exists(filename), "MPI loadstate file not found"
+        solver.load_state(filename)
+
+        # Check if fields were restored correctly
+        E_slice_loaded = solver.E[int(solver.Nx/2), int(solver.Ny/2), :, 'z']
+        assert np.allclose(E_slice, E_slice_loaded), "MPI loadstate failed to restore fields correctly"
+
+    @pytest.mark.skip(reason="Long test, enable when needed")
     def test_mpi_wakefield(self):
         # Reset fields
         global solver
@@ -284,7 +308,7 @@ class TestMPILossyCavity:
         # Run simulation
         solver.wakesolve(wakelength=wakelength,
                          wake=wake)
-
+    @pytest.mark.skip(reason="Long test, enable when needed")
     def test_long_wake_potential(self):
         global wake
         global solver
@@ -301,6 +325,7 @@ class TestMPILossyCavity:
             assert np.allclose(wake.WP[::50], self.WP, rtol=0.1), "Wake potential samples failed"
             assert np.cumsum(np.abs(wake.WP))[-1] == pytest.approx(184.43818552913254, 0.1), "Wake potential cumsum MPI failed"
 
+    @pytest.mark.skip(reason="Long test, enable when needed")
     def test_long_impedance(self):
         global wake
         global solver
@@ -321,6 +346,7 @@ class TestMPILossyCavity:
             assert np.allclose(np.imag(wake.Z)[::20], np.imag(self.Z), rtol=0.1), "Imag Impedance samples failed"
             assert np.cumsum(np.abs(wake.Z))[-1] == pytest.approx(250910.51090497518, 0.1), "Abs Impedance cumsum failed"
 
+    @pytest.mark.skip(reason="Long test, enable when needed")
     def test_log_file(self):
         # Helper function to compare nested dicts with float tolerance
         def assert_dict_allclose(d1, d2, rtol=1e-6, atol=1e-12, path=""):

--- a/wakis/field.py
+++ b/wakis/field.py
@@ -22,7 +22,7 @@ class Field:
     n = 1 + (i-1) + (j-1)*Nx + (k-1)*Nx*Ny
     len(n) = Nx*Ny*Nz
     '''
-    def __init__(self, Nx, Ny, Nz, dtype=float, 
+    def __init__(self, Nx, Ny, Nz, dtype=float,
                  use_ones=False, use_gpu=False):
 
         self.Nx = Nx
@@ -39,7 +39,7 @@ class Field:
                 print('*** cupy could not be imported, please CUDA check installation')
         else:
             self.xp = xp
-            
+
         if use_ones:
             self.array = self.xp.ones(self.N*3, dtype=self.dtype, order='F')
         else:
@@ -52,7 +52,7 @@ class Field:
     @property
     def field_y(self):
         return self.array[self.N: 2*self.N]
-    
+
     @property
     def field_z(self):
         return self.array[2*self.N:3*self.N]
@@ -101,7 +101,7 @@ class Field:
             self.array[2*self.N:3*self.N] = self.xp.reshape(mat, self.N, order='F')
         else:
             raise IndexError('Component id not valid')
-    
+
     def to_gpu(self):
         if imported_cupy:
             self.xp = xp_gpu
@@ -159,7 +159,7 @@ class Field:
                     return self.array[key]
             else:
                 raise IndexError('Lexico-graphic index cannot be higher than product of dimensions')
-            
+
         elif type(key) is slice:
             if self.on_gpu:
                 return self.array[key].get()
@@ -187,9 +187,9 @@ class Field:
                 self.array[key] = value
             else:
                 raise IndexError('Lexico-graphic index cannot be higher than product of dimensions')
-            
+
         elif type(key) is slice:
-                self.array[key] = value   
+                self.array[key] = value
         else:
             raise IndexError('key must be a 3-tuple or an integer')
 
@@ -203,13 +203,13 @@ class Field:
             mulField = Field(self.Nx, self.Ny, self.Nz, dtype=dtype)
             mulField.array = self.array * other
 
-        # other is matrix 
+        # other is matrix
         elif len(other.shape) > 1:
             mulField = Field(self.Nx, self.Ny, self.Nz, dtype=dtype)
             for d in ['x', 'y', 'z']:
                 mulField.from_matrix(self.to_matrix(d) * other, d)
 
-        # other is 1d array 
+        # other is 1d array
         else:
             mulField = Field(self.Nx, self.Ny, self.Nz, dtype=dtype)
             mulField.array = self.array * other
@@ -232,7 +232,7 @@ class Field:
             for d in ['x', 'y', 'z']:
                 divField.from_matrix(self.to_matrix(d) / other, d)
 
-        # other is constant or 1d array 
+        # other is constant or 1d array
         else:
             divField = Field(self.Nx, self.Ny, self.Nz, dtype=dtype)
             divField.array = self.array / other
@@ -243,21 +243,21 @@ class Field:
 
         if dtype is None:
             dtype = self.dtype
-        
+
         if type(other) is Field:
-            
+
             addField = Field(self.Nx, self.Ny, self.Nz, dtype=dtype)
             addField.field_x = self.field_x + other.field_x
             addField.field_y = self.field_y + other.field_y
-            addField.field_z = self.field_z + other.field_z  
-            
-        # other is matrix 
+            addField.field_z = self.field_z + other.field_z
+
+        # other is matrix
         elif len(other.shape) > 1:
             addField = Field(self.Nx, self.Ny, self.Nz, dtype=dtype)
             for d in ['x', 'y', 'z']:
                 addField.from_matrix(self.to_matrix(d) + other, d)
 
-        # other is constant or 1d array 
+        # other is constant or 1d array
         else:
             addField = Field(self.Nx, self.Ny, self.Nz, dtype=dtype)
             addField.array = self.array + other
@@ -273,9 +273,8 @@ class Field:
         return 'x:\n' + self.field_x.__str__() + '\n'+  \
                 'y:\n' + self.field_y.__str__() + '\n'+ \
                 'z:\n' + self.field_z.__str__()
-    
+
     def copy(self):
-        import copy
         obj = type(self).__new__(self.__class__)  # Create empty instance
 
         for key, value in self.__dict__.items():
@@ -304,12 +303,12 @@ class Field:
         '''
         if as_matrix:
             if self.on_gpu:
-                return xp.sqrt(self.to_matrix('x')**2 + 
-                            self.to_matrix('y')**2 + 
+                return xp.sqrt(self.to_matrix('x')**2 +
+                            self.to_matrix('y')**2 +
                             self.to_matrix('z')**2 ).get()
             else:
-                return xp.sqrt(self.to_matrix('x')**2 + 
-                            self.to_matrix('y')**2 + 
+                return xp.sqrt(self.to_matrix('x')**2 +
+                            self.to_matrix('y')**2 +
                             self.to_matrix('z')**2 )
 
         else: # 1d array
@@ -352,7 +351,7 @@ class Field:
 
         for d in [0,1,2]:
             field = self.to_matrix(d)
-            
+
             if self.on_gpu and hasattr(field, 'get'):
                 field = field.get()
 
@@ -370,12 +369,12 @@ class Field:
 
         if handles:
             return fig, axs
-        
+
         if show:
             plt.show()
 
     def inspect3D(self, field='all', backend='pyista', grid=None,
-                  xmax=None, ymax=None, zmax=None, 
+                  xmax=None, ymax=None, zmax=None,
                   bounding_box=True, show_grid=True,
                   cmap='viridis', dpi=100, show=True, handles=False):
         """
@@ -383,15 +382,15 @@ class Field:
         (voxel rendering) or PyVista (interactive clipping and slicing).
 
         This method provides two complementary visualization backends:
-        - **Matplotlib**: static voxel plots of the field components (x, y, z) 
+        - **Matplotlib**: static voxel plots of the field components (x, y, z)
           or all combined, useful for quick inspection, but memory intensive.
-        - **PyVista**: interactive 3D visualization with sliders to dynamically 
+        - **PyVista**: interactive 3D visualization with sliders to dynamically
           clip the volume along X, Y, and Z, and optional wireframe slices.
 
         Parameters
         ----------
         field : {'x', 'y', 'z', 'all'}, default 'all'
-            Which field component(s) to visualize. 
+            Which field component(s) to visualize.
             - 'x', 'y', 'z': single component
             - 'all': shows all three components
         backend : {'matplotlib', 'pyvista'}, default 'pyvista'
@@ -399,16 +398,16 @@ class Field:
             - 'matplotlib': static voxel rendering
             - 'pyvista': interactive 3D rendering with clipping sliders
         grid : GridFIT3D or pyvista.StructuredGrid, optional
-            Structured grid object to use for visualization. If None, 
+            Structured grid object to use for visualization. If None,
             a grid is constructed from the solver's internal dimensions.
         xmax, ymax, zmax : int or float, optional
-            Maximum extents in each direction for visualization. Defaults 
+            Maximum extents in each direction for visualization. Defaults
             to the full grid dimensions if not specified.
         bounding_box : bool, default True
-            If True, draw a wireframe bounding box of the simulation domain 
+            If True, draw a wireframe bounding box of the simulation domain
             (only used in PyVista backend).
         show_grid : bool, default True
-            If True, show wireframe slice planes of the grid during 
+            If True, show wireframe slice planes of the grid during
             interactive visualization (PyVista backend).
         cmap : str, default 'viridis'
             Colormap to apply to the scalar field.
@@ -418,7 +417,7 @@ class Field:
             Whether to display the figure/plot immediately.
             - If False in PyVista, exports to `field.html` instead.
         handles : bool, default False
-            If True, return figure/axes (Matplotlib) or the Plotter object 
+            If True, return figure/axes (Matplotlib) or the Plotter object
             (PyVista) for further customization instead of showing directly.
 
         Returns
@@ -430,10 +429,10 @@ class Field:
 
         Notes
         -----
-        - The PyVista backend provides interactive sliders to clip the 
-          volume along each axis independently and inspect internal 
+        - The PyVista backend provides interactive sliders to clip the
+          volume along each axis independently and inspect internal
           structures of the 3D field.
-        - The Matplotlib backend provides a quick static voxel rendering 
+        - The Matplotlib backend provides a quick static voxel rendering
           but is limited in interactivity and scalability.
 
         """
@@ -444,7 +443,6 @@ class Field:
         if backend.lower() == 'matplotlib':
             import matplotlib.pyplot as plt
             import matplotlib as mpl
-            from mpl_toolkits.axes_grid1 import make_axes_locatable
 
             fig = plt.figure(tight_layout=True, dpi=dpi, figsize=[12,6])
 
@@ -455,13 +453,19 @@ class Field:
                 plot_y = True
                 plot_z = True
 
-            elif field.lower() == 'x': plot_x = True
-            elif field.lower() == 'y': plot_y = True
-            elif field.lower() == 'z': plot_z = True
+            elif field.lower() == 'x':
+                plot_x = True
+            elif field.lower() == 'y':
+                plot_y = True
+            elif field.lower() == 'z':
+                plot_z = True
 
-            if xmax is None: xmax = self.Nx
-            if ymax is None: ymax = self.Ny
-            if zmax is None: zmax = self.Nz
+            if xmax is None:
+                xmax = self.Nx
+            if ymax is None:
+                ymax = self.Ny
+            if zmax is None:
+                zmax = self.Nz
 
             x,y,z = self.xp.mgrid[0:xmax+1,0:ymax+1,0:zmax+1]
             axs = []
@@ -473,16 +477,16 @@ class Field:
                     ax = fig.add_subplot(1, 3, 1, projection='3d')
                 else:
                     ax = fig.add_subplot(1, 1, 1, projection='3d')
-                
+
                 vmin, vmax = -self.xp.max(self.xp.abs(arr)), +self.xp.max(self.xp.abs(arr))
                 norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
                 colors = mpl.colormaps[cmap](norm(arr))
-                vox = ax.voxels(x, y, z, filled=self.xp.ones_like(arr), facecolors=colors)
-                
+                _ = ax.voxels(x, y, z, filled=self.xp.ones_like(arr), facecolors=colors)
+
                 m = mpl.cm.ScalarMappable(cmap=cmap, norm=norm)
                 m.set_array([])
                 fig.colorbar(m, ax=ax, shrink=0.5, aspect=10)
-                ax.set_title(f'Field x')
+                ax.set_title('Field x')
                 axs.append(ax)
 
             # field y
@@ -492,16 +496,16 @@ class Field:
                     ax = fig.add_subplot(1, 3, 2, projection='3d')
                 else:
                     ax = fig.add_subplot(1, 1, 1, projection='3d')
-                
+
                 vmin, vmax = -self.xp.max(self.xp.abs(arr)), +self.xp.max(self.xp.abs(arr))
                 norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
                 colors = mpl.colormaps[cmap](norm(arr))
-                vox = ax.voxels(x, y, z, filled=self.xp.ones_like(arr), facecolors=colors)
-                
+                _ = ax.voxels(x, y, z, filled=self.xp.ones_like(arr), facecolors=colors)
+
                 m = mpl.cm.ScalarMappable(cmap=cmap, norm=norm)
                 m.set_array([])
                 fig.colorbar(m, ax=ax, shrink=0.5, aspect=10)
-                ax.set_title(f'Field y')
+                ax.set_title('Field y')
                 axs.append(ax)
 
             # field z
@@ -515,15 +519,14 @@ class Field:
                 vmin, vmax = -self.xp.max(self.xp.abs(arr)), +self.xp.max(self.xp.abs(arr))
                 norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
                 colors = mpl.colormaps[cmap](norm(arr))
-                vox = ax.voxels(x, y, z, filled=self.xp.ones_like(arr), facecolors=colors)
-                
+                _ = ax.voxels(x, y, z, filled=self.xp.ones_like(arr), facecolors=colors)
+
                 m = mpl.cm.ScalarMappable(cmap=cmap, norm=norm)
                 m.set_array([])
                 fig.colorbar(m, ax=ax, shrink=0.5, aspect=10)
-                ax.set_title(f'Field z')
+                ax.set_title('Field z')
                 axs.append(ax)
 
-            dims = {0:'x', 1:'y', 2:'z'}
             for i, ax in enumerate(axs):
                 ax.set_xlabel('Nx')
                 ax.set_ylabel('Ny')
@@ -537,12 +540,12 @@ class Field:
 
             if handles:
                 return fig, axs
-            
+
             if show:
                 plt.show()
 
         # ----------- pyvista backend ---------------
-        else: 
+        else:
             import pyvista as pv
 
             if grid is not None and hasattr(grid, 'grid'):
@@ -561,9 +564,12 @@ class Field:
                     scalars = 'Field '+'Abs'
                     grid[scalars] = xp.reshape(self.get_abs(), self.N)
 
-                if xmax is None: xmax = xhi
-                if ymax is None: ymax = yhi
-                if zmax is None: zmax = zhi
+                if xmax is None:
+                    xmax = xhi
+                if ymax is None:
+                    ymax = yhi
+                if zmax is None:
+                    zmax = zhi
 
             else:
                 print('[!] `grid` is not passed or is not a GridFIT3D object -> Using #N cells instead ')
@@ -571,9 +577,12 @@ class Field:
                 y = xp.linspace(0, self.Ny, self.Ny+1)
                 z = xp.linspace(0, self.Nz, self.Nz+1)
                 xlo, xhi, ylo, yhi, zlo, zhi = x.min(), x.max(), y.min(), y.max(), z.min(), z.max()
-                if xmax is None: xmax = self.Nx
-                if ymax is None: ymax = self.Ny
-                if zmax is None: zmax = self.Nz
+                if xmax is None:
+                    xmax = self.Nx
+                if ymax is None:
+                    ymax = self.Ny
+                if zmax is None:
+                    zmax = self.Nz
                 X, Y, Z = xp.meshgrid(x, y, z, indexing='ij')
                 grid = pv.StructuredGrid(X.transpose(), Y.transpose(), Z.transpose())
 
@@ -648,8 +657,7 @@ class Field:
             pl.camera.azimuth += 30
             pl.camera.elevation += 30
             pl.set_background('mistyrose', top='white')
-            try: pl.add_logo_widget('../docs/img/wakis-logo-pink.png')
-            except: pass
+            self._add_logo_widget(pl)
             pl.add_axes()
             pl.enable_3_lights()
             pl.enable_anti_aliasing()
@@ -662,6 +670,22 @@ class Field:
                 return pl
 
             if not show:
-                pl.export_html(f'field.html')
+                pl.export_html('field.html')
             else:
                 pl.show()
+
+    def _add_logo_widget(self, pl):
+        """Add packaged logo via importlib.resources (Python 3.9+)."""
+        try:
+            from importlib import resources
+            # resource inside the installed package (use current package)
+            logo_res = resources.files(__package__).joinpath('static', 'img', 'wakis-logo-pink.png')
+            with resources.as_file(logo_res) as logo_path:
+                pl.add_logo_widget(str(logo_path))
+                return
+        except Exception:
+            # fallback to the legacy relative path for dev installs
+            try:
+                pl.add_logo_widget('../docs/img/wakis-logo-pink.png')
+            except Exception:
+                pass

--- a/wakis/gridFIT3D.py
+++ b/wakis/gridFIT3D.py
@@ -649,7 +649,7 @@ class GridFIT3D:
             try:
                 pl.add_logo_widget('../docs/img/wakis-logo-pink.png')
             except Exception:
-                if self.verbose > 1:
+                if self.verbose > 2:
                     print(f'[!] Could not add logo widget: {e}')
 
     def plot_solids(self, bounding_box=False, show_grid=False, anti_aliasing=None,

--- a/wakis/plotting.py
+++ b/wakis/plotting.py
@@ -974,5 +974,5 @@ class PlotMixin:
             try:
                 pl.add_logo_widget('../docs/img/wakis-logo-pink.png')
             except Exception:
-                if self.verbose > 1:
+                if self.verbose > 2:
                     print(f'[!] Could not add logo widget: {e}')

--- a/wakis/solverFIT3D.py
+++ b/wakis/solverFIT3D.py
@@ -37,7 +37,7 @@ class SolverFIT3D(PlotMixin, RoutinesMixin):
                  bc_high=['Periodic', 'Periodic', 'Periodic'],
                  use_stl=False, use_conductors=False,
                  use_gpu=False, use_mpi=False, dtype=np.float64,
-                 use_sibc=True, fmax=None,
+                 use_sibc=True, fmax=1e9,
                  n_pml=10, bg=[1.0, 1.0], verbose=1):
         '''
         Class holding the 3D time-domain electromagnetic solver

--- a/wakis/wakeSolver.py
+++ b/wakis/wakeSolver.py
@@ -20,11 +20,11 @@ class WakeSolver():
     '''
 
     def __init__(self, wakelength=None, q=1e-9, sigmaz=1e-3, beta=1.0,
-                 xsource=0., ysource=0., xtest=0., ytest=0., 
-                 chargedist=None, ti=None, 
-                 compute_plane='both', skip_cells=0, add_space=None, 
+                 xsource=0., ysource=0., xtest=0., ytest=0.,
+                 chargedist=None, ti=None,
+                 compute_plane='both', skip_cells=0, add_space=None,
                  Ez_file=None, save=True, results_folder='results/',
-                 verbose=0, counter_moving=False):
+                 verbose=1, counter_moving=False):
         '''
         Parameters
         ----------
@@ -110,6 +110,8 @@ class WakeSolver():
             This determines de size of the 3d wake potential
 
         '''
+        self.verbose = verbose
+        print('Initializing WakeSolver...')
 
         #beam
         self.q = q
@@ -123,11 +125,16 @@ class WakeSolver():
         self.skip_cells = skip_cells
         self.compute_plane = compute_plane
         self.DE_model = None
+        self.fmax = self.v/self.sigmaz/3
+
+        self.log(f'* Beam longitudinal sigma sigmaz={self.sigmaz*1e3} mm, sigmat={self.sigmaz/self.v*1e9} ns')
+        self.log(f'* Maximum frequency of interest fmax={self.fmax/1e9} GHz')
 
         self.counter_moving = counter_moving
 
         if add_space is not None: #legacy support for add_space
             self.skip_cells = add_space
+            self.log(f'* Field values skipped from boundaries: {self.skip_cells} cells')
 
         # Injection time
         if ti is not None:
@@ -136,6 +143,7 @@ class WakeSolver():
             #ti = 8.548921333333334*self.sigmaz/self.v  #injection time as in CST for beta = 1
             ti = 8.548921333333334*self.sigmaz/(np.sqrt(self.beta)*self.v) #injection time as in CST for beta <=1
             self.ti = ti
+            self.log(f'* Beam source injection time ti={self.ti} s')
 
         #field
         self.Ez_file = Ez_file
@@ -159,7 +167,6 @@ class WakeSolver():
         self.lambdaf = None
 
         #user
-        self.verbose = verbose
         self.logger = Logger()
         self.save = save
         self.folder = results_folder
@@ -170,7 +177,7 @@ class WakeSolver():
         if self.save:
             if not os.path.exists(self.folder):
                 os.mkdir(self.folder)
-        
+
         self.assign_logs()
 
     def solve(self, compute_plane=None, **kwargs):
@@ -342,7 +349,7 @@ class WakeSolver():
         # check for rounding errors
         if nt > len(keys)-4:
             nt = len(keys)-4
-            self.log('*** rounding error in number of timesteps')
+            self.log('[!] Rounding error in number of timesteps')
 
         # Assembly Ez field
         self.log('Assembling Ez field...')
@@ -398,10 +405,6 @@ class WakeSolver():
             Number of transverse cells used for the 3d calculation: 2*n+1
             This determines de size of the 3d wake potential
         '''
-        self.log('\n')
-        self.log('Longitudinal wake potential')
-        self.log('-'*24)
-
         for key, val in kwargs.items():
             setattr(self, key, val)
 
@@ -450,7 +453,7 @@ class WakeSolver():
         # check for rounding errors
         if nt > len(keys)-4:
             nt = len(keys)-4
-            self.log('*** rounding error in number of timesteps')
+            self.log('[!] Rounding error in number of timesteps')
 
         print('Calculating longitudinal wake potential WP(s)')
         with tqdm(total=len(s)*(i0*2+1)*(j0*2+1)) as pbar:
@@ -526,9 +529,6 @@ class WakeSolver():
         for key, val in kwargs.items():
             setattr(self, key, val)
 
-        self.log('\n')
-        self.log('Transverse wake potential')
-        self.log('-'*24)
         self.log(f'* No. transverse cells = {self.n_transverse_cells}')
 
         # Obtain dx, dy, ds
@@ -597,15 +597,10 @@ class WakeSolver():
             Beam sigma in the longitudinal direction [m].
             Used to calculate maximum frequency of interest fmax=c/(3*sigmaz)
         '''
-        self.log('\n')
-        self.log('Longitudinal impedance')
-        self.log('-'*24)
-
         for key, val in kwargs.items():
             setattr(self, key, val)
 
         print('Calculating longitudinal impedance Z...')
-        self.log(f'Single sided DFT with number of samples = {samples}')
 
         # setup charge distribution in s
         if self.lambdas is None and self.chargedist is not None:
@@ -613,15 +608,17 @@ class WakeSolver():
         elif self.lambdas is None and self.chargedist is None:
             self.calc_lambdas_analytic()
             try:
-                self.log('! Using analytic charge distribution λ(s) since no data was provided')
+                self.log('[!] Using analytic charge distribution λ(s) since no data was provided')
             except Exception: #ascii encoder error handling
-                self.log('! Using analytic charge distribution since no data was provided')
+                self.log('[!] Using analytic charge distribution since no data was provided')
 
         # Set up the DFT computation
         ds = np.mean(self.s[1:]-self.s[:-1])
         if fmax is None:
-            fmax = self.v/self.sigmaz/3   #max frequency of interest
+            fmax = self.fmax   #max frequency of interest
         N = int((self.v/ds)//fmax*samples) #to obtain a 1000 sample single-sided DFT
+        self.log(f'* Single sided DFT with number of samples = {samples} and fmax = {fmax}')
+        self.log(f'* Zero-padding to N = {N} points with ds = {ds} m')
 
         # Obtain DFTs - is it v or c?
         lambdafft = np.fft.fft(self.lambdas*self.v, n=N)
@@ -649,21 +646,17 @@ class WakeSolver():
         single-sided DFT with 1000 samples
         Parameters can be passed as **kwargs
         '''
-        self.log('\n')
-        self.log('Transverse impedance')
-        self.log('-'*24)
-
         print('Calculating transverse impedance Zx, Zy...')
-        self.log(f'Single sided DFT with number of samples = {samples}')
 
         # Set up the DFT computation
         ds = np.mean(self.s[1:]-self.s[:-1])
         if fmax is None:
-            fmax = self.v/self.sigmaz/3   #max frequency of interest
+            fmax = self.fmax  #max frequency of interest
         N = int((self.v/ds)//fmax*samples) #to obtain a 1000 sample single-sided DFT
+        self.log(f'* Single-sided DFT with number of samples = {samples} and fmax = {fmax}')
+        self.log(f'* Zero-padding to N = {N} points with ds = {ds} m')
 
         # Obtain DFTs
-
         # Normalized charge distribution λ(w)
         lambdafft = np.fft.fft(self.lambdas*self.v, n=N)
         ffft=np.fft.fftfreq(len(lambdafft), ds/self.v)
@@ -729,7 +722,7 @@ class WakeSolver():
             elif len(self.zf) == len(self.chargedist):
                 z = self.zf
             else:
-                self.log('Dimension error: check input dimensions')
+                self.log('[!] Dimension error: check input dimensions')
 
         self.lambdas = np.interp(self.s, z, chargedist/self.q)
 
@@ -789,6 +782,7 @@ class WakeSolver():
                          use_minimization=True, minimization_margin=[0.3, 0.2, 0.01],
                          minimum_peak_height=1.0, distance=3, inspect_bounds=False,
                          Rs_bounds=[0.8, 10], Q_bounds=[0.5, 5], fres_bounds=[-0.01e9, +0.01e9],
+                         verbose=0,
                          ):
         import iddefix
 
@@ -851,7 +845,7 @@ class WakeSolver():
 
         self.DE_model = DE_model
         self.log(DE_model.warning)
-        if self.verbose:
+        if verbose:
             print(DE_model.warning)
 
         return DE_model
@@ -1127,8 +1121,10 @@ class WakeSolver():
         obj.__dict__.update(self.__dict__)
         return obj
 
-    def log(self, txt):
-        if self.verbose:
+    def log(self, txt, level=0):
+        if self.verbose and level==0:
+            print(txt)
+        elif self.verbose and level==1:
             print('\x1b[2;37m'+txt+'\x1b[0m')
 
     def read_cst_3d(self, path=None, folder='3d', filename='Ez.h5', units=1e-3):


### PR DESCRIPTION
## 📝 Pull Request Summary
<!-- Briefly describe what this PR does and why it's needed. -->

This pull request introduces several improvements and refactorings to the handling of STL-based materials and the solver infrastructure for the 3D grid simulation package. The main changes focus on enhancing flexibility in material assignment, supporting the Surface Impedance Boundary Condition (SIBC) for high-conductivity materials, and refactoring solver methods for better code organization and maintainability.

## 🔧 Changes Made
<!-- List the key changes introduced in this PR. -->

**STL Material Handling and SIBC Support**

* Added support for SIBC (Leontovich boundary condition) in `GridFIT3D`, which is automatically applied to STL solids with conductivity greater than 1e3 S/m. This involves marking only the surface cells for such materials. (`wakis/gridFIT3D.py`) [[1]](diffhunk://#diff-348e31a5819e1252461af8925af734fee402a25608a186dcb9b549993a05f3f1R60-R62) [[2]](diffhunk://#diff-348e31a5819e1252461af8925af734fee402a25608a186dcb9b549993a05f3f1R207-R208) [[3]](diffhunk://#diff-348e31a5819e1252461af8925af734fee402a25608a186dcb9b549993a05f3f1R414-R423)
* Improved STL material assignment: string keys are now mapped to material properties using `material_lib`, and all STL material data is normalized to dictionary format for consistency. (`wakis/gridFIT3D.py`)
* Changed the default vacuum material representation from `'vacuum'` to `[1.0, 1.0]` for consistency and improved opacity handling in plotting. (`tests/test_007_mpi_lossy_cavity.py`, `wakis/gridFIT3D.py`) [[1]](diffhunk://#diff-ef5dde3f223c3fb2a7d071f3dd7dc5061e0e9983afb3e48cfaee49df12d46252L95-R95) [[2]](diffhunk://#diff-348e31a5819e1252461af8925af734fee402a25608a186dcb9b549993a05f3f1L658-R697)

**Solver Infrastructure Refactoring**

* Refactored solver step and MPI-related methods to use private method naming (`_one_step`, `_mpi_one_step`, etc.), improving code clarity and encapsulation. Public methods now delegate to these internal implementations. (`wakis/solverFIT3D.py`) [[1]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914L152-R154) [[2]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914L255-R256) [[3]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914L309-R352) [[4]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914L327-R372) [[5]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914L347-R388) [[6]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914L357-R421)
* Consolidated STL material application logic into a new `_apply_stl_materials` method in the solver, ensuring correct assignment of permittivity, permeability, and conductivity to grid cells. (`wakis/solverFIT3D.py`) [[1]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914L205-R206) [[2]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914R276-R315)

**Other Improvements**

* Updated legacy conductor support methods with private naming and deprecation notices, preparing for future removal. (`wakis/solverFIT3D.py`) [[1]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914R64) [[2]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914L923-R966) [[3]](diffhunk://#diff-10bae9c28cfac00ec8fdfd99e562f438c41775576b6ffc3410f92808f7452914L933-R977)
* Updated the test simulation to use the refactored `one_step` method instead of the old MPI-specific method for improved compatibility. (`tests/test_007_mpi_lossy_cavity.py`)

## ✅ Checklist
- [x] Code follows the project's style and guidelines
- [ ] Added tests for new functionality 
- [ ] Updated documentation (mentioned in `docs/` or included in `examples/` and `notebooks/`)
- [x] Verified that changes do not break existing functionality (automatic tests passing)

## 📌 Related Issues / PRs
<!-- Link any related issues or PRs using `#issue-number`. -->
Closes #45 
