### PR TITLE
:sparkles: Addition of new CAD importing methods in GridFIT3D

### DIFF
--- a/wakis/gridFIT3D.py
+++ b/wakis/gridFIT3D.py
@@ -57,6 +57,7 @@ class GridFIT3D(PlotMixin):
         stl_scale=1.0,
         stl_colors=None,
         stl_tol=1e-3,
+        stl_method="Wakis_v070",
         load_from_h5=None,
         verbose=1,
     ):
@@ -106,6 +107,9 @@ class GridFIT3D(PlotMixin):
         stl_tol : float, optional
             Tolerance factor for STL import, used in grid.select_enclosed_points.
             Default is 1e-3.
+        stl_method : str, optional
+            Method for marking cells inside STL solids. Options are "interior_points" (default),
+            "implicit_distance", or "voxelize_rectilinear".
         load_from_h5 : str, optional
             Load grid from an h5 file previously saved with `save_to_h5`.
         verbose : int or bool, optional
@@ -246,8 +250,9 @@ class GridFIT3D(PlotMixin):
         if verbose:
             print("Importing STL solids...")
         self.stl_tol = stl_tol
+        self.stl_method = stl_method
         if stl_solids is not None:
-            self._mark_cells_in_stl()
+            self._mark_cells_in_stl(method=self.stl_method)
 
         if verbose:
             print(f"Total grid initialization time: {time.time() - t0} s")
@@ -467,11 +472,13 @@ class GridFIT3D(PlotMixin):
                     sigma = material_lib[mat_key][2]
                     self.stl_materials[key].append(sigma)
 
-    def _mark_cells_in_stl(self):
+    def _mark_cells_in_stl(self, method):
         """
         Mark grid cells that are inside each STL solid.
 
-        Uses PyVista's select_enclosed_points to create boolean masks for each solid.
+        Uses PyVista's select_interior_points as default (equivalent to the deprecated select_enclosedpoints),
+        and otherwise input method either compute_implicit_distance or voxelize_rectilinear,
+        to create boolean masks for each solid.
         """
         # Obtain masks with grid cells inside each stl solid
         stl_tolerance = (
@@ -480,35 +487,108 @@ class GridFIT3D(PlotMixin):
         progress_bar = False
         if self.Nx * self.Ny * self.Nz > 5e6 and self.verbose:
             progress_bar = True
+
         for key in self.stl_solids.keys():
             surf = self.read_stl(key)
 
             # mark cells in stl [True == in stl, False == out stl]
-            try:
-                select = self.grid.select_enclosed_points(
-                    surf, tolerance=stl_tolerance, progress_bar=progress_bar
-                )
-            except Exception:
-                select = self.grid.select_enclosed_points(
-                    surf,
-                    tolerance=stl_tolerance,
-                    check_surface=False,
-                    progress_bar=progress_bar,
-                )
-                if self.verbose > 1:
+            if method == "Wakis_v070":
+                try:
+                    select = self.grid.select_interior_points(
+                        surf, method="cell_locator", locator_tolerance=stl_tolerance
+                    )
+                    self.grid[key] = (
+                        select.point_data_to_cell_data()["selected_points"]
+                        > stl_tolerance
+                    )
+                except Exception:
+                    select = self.grid.select_interior_points(
+                        surf,
+                        method="cell_locator",
+                        locator_tolerance=stl_tolerance,
+                        check_surface=False,
+                    )
+                    self.grid[key] = (
+                        select.point_data_to_cell_data()["selected_points"]
+                        > stl_tolerance
+                    )
+                    if self.verbose > 1:
+                        print(
+                            f"[!] Warning: stl solid {key} may have issues with closed surfaces. Consider checking the STL file."
+                        )
+
+            elif method == "interior_points":
+                try:
+                    select = self.grid.select_interior_points(
+                        surf, method="cell_locator", locator_tolerance=stl_tolerance
+                    )
+                    self.grid[key] = (
+                        select.point_data_to_cell_data()["selected_points"] > 0.5
+                    )
+                except Exception:
+                    select = self.grid.select_interior_points(
+                        surf,
+                        method="cell_locator",
+                        locator_tolerance=stl_tolerance,
+                        check_surface=False,
+                    )
+                    self.grid[key] = (
+                        select.point_data_to_cell_data()["selected_points"] > 0.5
+                    )
+                    if self.verbose > 1:
+                        print(
+                            f"[!] Warning: stl solid {key} may have issues with closed surfaces. Consider checking the STL file."
+                        )
+
+            elif method == "implicit_distance":
+                # negative distance is inside, positive is outside
+                try:
+                    select = self.grid.compute_implicit_distance(surf)
+                    self.grid[key] = select.point_data_to_cell_data()[
+                        "implicit_distance"
+                    ] <= 0.5 * np.mean(
+                        [np.mean(self.dx), np.mean(self.dy), np.mean(self.dz)]
+                    )
+                except Exception:
                     print(
-                        f"[!] Warning: stl solid {key} may have issues with closed surfaces. \
-                        Consider checking the STL file."
+                        f"[!] Warning: Implicit distance computation for stl solid {key} failed."
                     )
 
-            self.grid[key] = (
-                select.point_data_to_cell_data()["SelectedPoints"] > stl_tolerance
-            )
+            elif method == "voxelize_rectilinear":
+                dx, dy, dz = (
+                    (self.xmax - self.xmin) / (self.Nx),
+                    (self.ymax - self.ymin) / (self.Ny),
+                    (self.zmax - self.zmin) / (self.Nz),
+                )
+                reference_vol = pv.ImageData(
+                    dimensions=(self.Nx, self.Ny, self.Nz),
+                    # origin=(self.xmin + dx / 2, self.ymin + dy / 2, self.zmin + dz / 2),
+                    # origin=(self.xmin - dx / 2, self.ymin - dy / 2, self.zmin - dz / 2),
+                    origin=(self.xmin, self.ymin, self.zmin),
+                    spacing=(dx, dy, dz),
+                )
+
+                try:
+                    vox = surf.voxelize_rectilinear(
+                        reference_volume=reference_vol, progress_bar=progress_bar
+                    )
+                    mask = np.reshape(
+                        vox["mask"], (self.Nx, self.Ny, self.Nz), order="F"
+                    ).astype(bool)
+                    self.grid[key] = np.reshape(mask, (self.Nx * self.Ny * self.Nz))
+                except Exception:
+                    print(
+                        f"[!] Warning: voxelization for stl solid {key} failed. Consider checking if the grid is uniform or using a different method."
+                    )
+            else:
+                raise ValueError(
+                    f"[!] Error: stl_method {method} not recognized. \
+                    Use 'interior_points', 'implicit_distance', or 'voxelize_rectilinear'."
+                )
 
             if self.verbose and np.sum(self.grid[key]) == 0:
                 print(
-                    f"[!] Warning: no cells were marked inside stl solid {key}. \
-                    Consider increasing the tolerance factor (currently {self.stl_tol})."
+                    f"[!] Warning: no cells were marked inside stl solid {key}. Consider increasing the tolerance factor (currently {self.stl_tol})."
                 )
 
             if self.verbose > 1:

--- a/wakis/gridFIT3D.py
+++ b/wakis/gridFIT3D.py
@@ -57,7 +57,7 @@ class GridFIT3D(PlotMixin):
         stl_scale=1.0,
         stl_colors=None,
         stl_tol=1e-3,
-        stl_method="Wakis_v070",
+        stl_method="legacy",
         load_from_h5=None,
         verbose=1,
     ):
@@ -476,9 +476,16 @@ class GridFIT3D(PlotMixin):
         """
         Mark grid cells that are inside each STL solid.
 
-        Uses PyVista's select_interior_points as default (equivalent to the deprecated select_enclosedpoints),
+        Uses PyVista's select_interior_points as default (equivalent to the deprecated select_enclosed_points),
         and otherwise input method either compute_implicit_distance or voxelize_rectilinear,
         to create boolean masks for each solid.
+
+        See also the PyVista documentation:
+        ----------------------------------
+        "interior_points": https://docs.pyvista.org/api/core/_autosummary/pyvista.datasetfilters.select_interior_points
+        "implicit_distance": https://docs.pyvista.org/api/core/_autosummary/pyvista.datasetfilters.compute_implicit_distance
+        "voxelize_rectilinear" : https://docs.pyvista.org/api/core/_autosummary/pyvista.datasetfilters.voxelize_rectilinear
+
         """
         # Obtain masks with grid cells inside each stl solid
         stl_tolerance = (
@@ -492,7 +499,7 @@ class GridFIT3D(PlotMixin):
             surf = self.read_stl(key)
 
             # mark cells in stl [True == in stl, False == out stl]
-            if method == "Wakis_v070":
+            if method.lower() == "legacy":
                 try:
                     select = self.grid.select_interior_points(
                         surf, method="cell_locator", locator_tolerance=stl_tolerance
@@ -517,7 +524,7 @@ class GridFIT3D(PlotMixin):
                             f"[!] Warning: stl solid {key} may have issues with closed surfaces. Consider checking the STL file."
                         )
 
-            elif method == "interior_points":
+            elif method.lower() == "interior_points":
                 try:
                     select = self.grid.select_interior_points(
                         surf, method="cell_locator", locator_tolerance=stl_tolerance
@@ -540,7 +547,7 @@ class GridFIT3D(PlotMixin):
                             f"[!] Warning: stl solid {key} may have issues with closed surfaces. Consider checking the STL file."
                         )
 
-            elif method == "implicit_distance":
+            elif method.lower() == "implicit_distance":
                 # negative distance is inside, positive is outside
                 try:
                     select = self.grid.compute_implicit_distance(surf)
@@ -554,7 +561,7 @@ class GridFIT3D(PlotMixin):
                         f"[!] Warning: Implicit distance computation for stl solid {key} failed."
                     )
 
-            elif method == "voxelize_rectilinear":
+            elif method.lower() == "voxelize_rectilinear":
                 dx, dy, dz = (
                     (self.xmax - self.xmin) / (self.Nx),
                     (self.ymax - self.ymin) / (self.Ny),


### PR DESCRIPTION
## 📝 Pull Request Summary
<!-- Briefly describe what this PR does and why it's needed. -->

## 🔧 Changes Made
- **Grid / STL / Geometry / Meshing**
    - Enhanced STL Meshing Framework
        - Refactored mark_cells_in_stl() to support three distinct PyVista-based meshing methods: select_interior_points, compute_implicit_distance, and voxelize_rectilinear.

        - Introduced voxelize_rectilinear as a more robust meshing option for non-manifold complex geometries.

        - Updated the default meshing logic from the deprecated select_enclosed_points to the updated select_interior_points method, and additionally added the select_interior_points method with a new point-to-cell boolean mask threshold to the static value 0.5 (the previous 'stl_tolerance' threshold was resolution dependent, and caused over-masking increasingly with grid resolution).

        - Added a new stl_method parameter to the GridFIT3D class to allow user-defined selection of the underlying meshing algorithm (however especially for non-manifold geometry CAD import and high grid resolution simulations, voxelize_rectilinear is suggested! ).



- **Solver / API Changes**
    - GridFIT3D Initialization
        - Updated the grid constructor to handle stl_method configuration, defaulting to select_interior_points with point-to-cell mask threshold of stl_tolerance as the legacy Wakis version, to maintain backward compatibility with the latest Wakis version.
 



## ✅ Checklist
- [x] Code follows the project's style and guidelines
- [ ] Added tests for new functionality **To do**
- [ ] Updated documentation (mentioned in `docs/` or included in `examples/` and `notebooks/`) **To do**
- [x] Verified that changes do not break existing functionality (automatic tests passing)

## 📌 Related Issues / PRs
<!-- Link any related issues or PRs using `#issue-number`. -->
Closes #issue-number
