### PR TITLE
Add 'ti' parameter to Beam initialization in 'wakesolve'

### DIFF
--- a/wakis/routines.py
+++ b/wakis/routines.py
@@ -374,6 +374,7 @@ class RoutinesMixin:
             q=self.wake.q,
             sigmaz=self.wake.sigmaz,
             beta=self.wake.beta,
+            ti=self.wake.ti,
             xsource=self.wake.xsource,
             ysource=self.wake.ysource,
         )


### PR DESCRIPTION
## 📝 Pull Request Summary

Pass the `WakeSolver` injection time to the `Beam` created in `wakesolve()`.

## 🔧 Changes Made

* Added `ti=self.wake.ti` to the `Beam` initialization.

## ✅ Checklist

* [x] Code follows the project's style and guidelines
* N/A Added tests for new functionality
* N/A Updated documentation (mentioned in `docs/` or included in `examples/` and `notebooks/`)
* [ ] Verified that changes do not break existing functionality (automatic tests passing)

## 📌 Related Issues / PRs

Closes #88
